### PR TITLE
Removed condition in onBlur() function

### DIFF
--- a/src/components/fields/DateText/index.js
+++ b/src/components/fields/DateText/index.js
@@ -57,9 +57,7 @@ export default class DateTextField extends React.Component {
 
   @autobind
   onBlur() {
-    if (!this.props.value) {
-      this.setState({text: ''})
-    }
+    this.setState({text: ''})
   }
 
   render() {


### PR DESCRIPTION
When state in parent form is cleaned, field DateText expect onBlur event to ve cleaned, opposite to other kinds of fields that are updated automatically, because this.props.value still exists.

It checks normally if the input is valid according to the date format. When the parent form state is updated, the field receive its value as prop, checks if it has the format, and set the input as empty